### PR TITLE
Update IMvcBuilderExtensions.cs

### DIFF
--- a/Source/Delve.AspNetCore/IMvcBuilderExtensions.cs
+++ b/Source/Delve.AspNetCore/IMvcBuilderExtensions.cs
@@ -31,6 +31,7 @@ namespace Delve.AspNetCore
             //Ignores CiruclarReference checking in json.net
             mvcBuilder.AddJsonOptions(opt => {
                 opt.SerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore;
+                opt.SerializerSettings.NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore;
             });
 
             return mvcBuilder;


### PR DESCRIPTION
In response we sometimes have null value for navigation property (e.g. role) like:
```json
{
	"id": 1,
	"firstName": "Veronica",
	"lastName": "Fear",
	"dateOfBirth": "1946-01-23T21:01:40",
	"userRoles": [
		{
			"id": 1,
			"userId": 1,
			"roleId": 4,
			"role": null
		}
	]
}
```
and IMHO it is unnecessarily to display `null` value to user.